### PR TITLE
Refactor API and fix review issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ poetry add jinja2sql
 from jinja2sql import Jinja2SQL
 
 
-j2sql = Jinja2SQL(param_style="named")  # default param style is "named"
+j2sql = Jinja2SQL()  # default param_style is "named"
 
 query, params = j2sql.from_string(
     "SELECT * FROM {{ table | identifier }} WHERE email = {{ email }}",

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ poetry add jinja2sql
 from jinja2sql import Jinja2SQL
 
 
-j2sql = Jinja2SQL(param_style="named")  # default param style is "named"
+j2sql = Jinja2SQL()  # default param_style is "named"
 
 query, params = j2sql.from_string(
     "SELECT * FROM {{ table | identifier }} WHERE email = {{ email }}",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -167,7 +167,32 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-## Customer filters
+## Raw SQL with `safe`
+
+By default, all template variables are automatically parameterized to prevent SQL injection.
+The Jinja2 built-in `safe` filter bypasses this behavior and inserts the value directly into the query **without parameterization**:
+
+```python
+from jinja2sql import Jinja2SQL
+
+j2sql = Jinja2SQL()
+
+query, params = j2sql.from_string(
+    "SELECT * FROM users ORDER BY {{ column | safe }} {{ direction | safe }}",
+    context={"column": "created_at", "direction": "DESC"},
+)
+
+assert query == "SELECT * FROM users ORDER BY created_at DESC"
+assert params == {}
+```
+
+!!! warning
+
+    **Never use `safe` with untrusted user input.** Values passed through `safe` are inserted into SQL as-is, which can lead to SQL injection. Use it only for values that you fully control in your code.
+
+    For dynamic table or column names, prefer the `identifier` filter instead — it provides proper escaping.
+
+## Custom filters
 
 `Jinja2SQL` supports custom filters to extend the functionality of the Jinja2 templating engine.
 
@@ -185,7 +210,7 @@ def array_filter(self: Jinja2SQL, value: list[str]) -> str:
 
 
 query, params = j2sql.from_string(
-    """SELECT ARRAY[{{ param | array2 }}] AS array""",
+    """SELECT ARRAY[{{ param | array }}] AS array""",
     context={
         "param": ["0", "1"],
     },

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,8 +40,9 @@ import jinja2
 
 from jinja2sql import Jinja2SQL
 
-env = jinja2.Environment(loader=jinja2.FileSystemLoader(Path(__name__).parent))
-j2sql = Jinja2SQL(env)
+j2sql = Jinja2SQL(
+    jinja2.Environment(loader=jinja2.FileSystemLoader(Path(__name__).parent))
+)
 
 query, params = j2sql.from_file(
     "query.sql",
@@ -109,8 +110,7 @@ import jinja2
 
 from jinja2sql import Jinja2SQL
 
-env = jinja2.Environment(enable_async=True)
-j2sql = Jinja2SQL(env)
+j2sql = Jinja2SQL(jinja2.Environment(enable_async=True))
 ```
 
 ### String Templates
@@ -124,8 +124,7 @@ import jinja2
 
 from jinja2sql import Jinja2SQL
 
-env = jinja2.Environment(enable_async=True)
-j2sql = Jinja2SQL(env)
+j2sql = Jinja2SQL(jinja2.Environment(enable_async=True))
 
 
 async def main() -> None:
@@ -162,10 +161,12 @@ import jinja2
 
 from jinja2sql import Jinja2SQL
 
-env = jinja2.Environment(
-    loader=jinja2.FileSystemLoader(Path(__name__).parent), enable_async=True
+j2sql = Jinja2SQL(
+    jinja2.Environment(
+        loader=jinja2.FileSystemLoader(Path(__name__).parent),
+        enable_async=True,
+    )
 )
-j2sql = Jinja2SQL(env)
 
 
 async def main() -> None:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ To generate SQL queries from string templates, use the `from_string` method:
 ```python
 from jinja2sql import Jinja2SQL
 
-j2sql = Jinja2SQL(param_style="named")  # default param style is "named"
+j2sql = Jinja2SQL()  # default param_style is "named"
 
 query, params = j2sql.from_string(
     "SELECT * FROM {{ table | identifier }} WHERE email = {{ email }}",
@@ -36,9 +36,12 @@ SELECT * FROM {{ table | identifier }} WHERE email = {{ email }}
 ```python
 from pathlib import Path
 
+import jinja2
+
 from jinja2sql import Jinja2SQL
 
-j2sql = Jinja2SQL(searchpath=Path(__name__).parent)  # default param style is "named"
+env = jinja2.Environment(loader=jinja2.FileSystemLoader(Path(__name__).parent))
+j2sql = Jinja2SQL(env)
 
 query, params = j2sql.from_file(
     "query.sql",
@@ -99,12 +102,15 @@ assert query == "SELECT * FROM table WHERE column = {email}"
 
 ## Async support
 
-`Jinja2SQL` supports asynchroneous query generation using the `enable_async` flag:
+`Jinja2SQL` supports asynchronous query generation. Pass a Jinja2 environment with `enable_async=True`:
 
 ```python
+import jinja2
+
 from jinja2sql import Jinja2SQL
 
-j2sql = Jinja2SQL(enable_async=True)
+env = jinja2.Environment(enable_async=True)
+j2sql = Jinja2SQL(env)
 ```
 
 ### String Templates
@@ -114,9 +120,12 @@ To generate SQL queries from string templates, use the `from_string_async` metho
 ```python
 import asyncio
 
+import jinja2
+
 from jinja2sql import Jinja2SQL
 
-j2sql = Jinja2SQL(param_style="named", enable_async=True)
+env = jinja2.Environment(enable_async=True)
+j2sql = Jinja2SQL(env)
 
 
 async def main() -> None:
@@ -149,9 +158,14 @@ SELECT * FROM {{ table | identifier }} WHERE email = {{ email }}
 import asyncio
 from pathlib import Path
 
+import jinja2
+
 from jinja2sql import Jinja2SQL
 
-j2sql = Jinja2SQL(searchpath=Path(__name__).parent, enable_async=True)
+env = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(Path(__name__).parent), enable_async=True
+)
+j2sql = Jinja2SQL(env)
 
 
 async def main() -> None:
@@ -166,6 +180,35 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
+
+## Manual binding with `autobind=False`
+
+By default, `Jinja2SQL` automatically parameterizes all template variables. If you prefer explicit control, disable auto-binding:
+
+```python
+from jinja2sql import Jinja2SQL
+
+j2sql = Jinja2SQL(autobind=False)
+
+query, params = j2sql.from_string(
+    "SELECT * FROM {{ table | identifier }}"
+    " WHERE email = {{ email | bind('email') }}"
+    " AND status IN {{ statuses | inclause('statuses') }}",
+    context={
+        "table": "users",
+        "email": "user@mail.com",
+        "statuses": ["active", "pending"],
+    },
+)
+
+assert query == (
+    'SELECT * FROM users'
+    ' WHERE email = :email__1'
+    ' AND status IN (:statuses__in__2, :statuses__in__3)'
+)
+```
+
+With `autobind=False`, variables without an explicit `bind` or `_bind_in` filter are rendered as plain text — no parameterization is applied.
 
 ## Raw SQL with `safe`
 
@@ -207,15 +250,24 @@ j2sql = Jinja2SQL()
 @j2sql.filter
 def lowercase(value: str) -> str:
     return value.lower()
+
+
+# or using register_filter
+j2sql.register_filter("lowercase", lambda value: value.lower())
 ```
 
-If you need access to the `Jinja2SQL` instance inside your filter (e.g. to call `identifier`), pass `bind=True` — the instance will be injected as the first argument:
+If you need access to the `Jinja2SQL` instance inside your filter, pass `bind=True` — the instance will be injected as the first argument:
 
 ```python
-@j2sql.filter(name="array", bind=True)
-def array_filter(j2sql: Jinja2SQL, value: list[str]) -> str:
-    return j2sql.identifier(", ".join(f"'{item}'" for item in value))
+from jinja2sql import Jinja2SQL, identifier
 
+
+def array_filter(j2sql: Jinja2SQL, value: list[str]) -> str:
+    parts = ", ".join(f"'{item}'" for item in value)
+    return identifier(j2sql, parts)
+
+
+j2sql.register_filter("array", array_filter, bind=True)
 
 query, params = j2sql.from_string(
     """SELECT ARRAY[{{ param | array }}] AS array""",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -204,9 +204,17 @@ from jinja2sql import Jinja2SQL
 j2sql = Jinja2SQL()
 
 
-@j2sql.filter(name="array")   # or j2sql.register_filter("array", array_filter)
-def array_filter(self: Jinja2SQL, value: list[str]) -> str:
-    return self.identifier(", ".join(f"'{item}'" for item in value))
+@j2sql.filter
+def lowercase(value: str) -> str:
+    return value.lower()
+```
+
+If you need access to the `Jinja2SQL` instance inside your filter (e.g. to call `identifier`), pass `bind=True` — the instance will be injected as the first argument:
+
+```python
+@j2sql.filter(name="array", bind=True)
+def array_filter(j2sql: Jinja2SQL, value: list[str]) -> str:
+    return j2sql.identifier(", ".join(f"'{item}'" for item in value))
 
 
 query, params = j2sql.from_string(

--- a/jinja2sql/__init__.py
+++ b/jinja2sql/__init__.py
@@ -1,3 +1,8 @@
-from ._core import Jinja2SQL
+from ._core import Jinja2SQL, bind, bind_in, identifier
 
-__all__ = ["Jinja2SQL"]
+__all__ = [
+    "Jinja2SQL",
+    "bind",
+    "bind_in",
+    "identifier",
+]

--- a/jinja2sql/_core.py
+++ b/jinja2sql/_core.py
@@ -5,7 +5,7 @@ import inspect
 import os
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextvars import ContextVar
-from typing import Any, Literal, Protocol, TypeAlias, TypeVar, overload
+from typing import Any, Literal, ParamSpec, Protocol, TypeAlias, TypeVar, overload
 
 import jinja2
 import jinja2.defaults
@@ -14,7 +14,6 @@ from jinja2.ext import Extension
 from jinja2.lexer import Token, TokenStream
 from jinja2.parser import Parser
 from markupsafe import Markup
-from typing_extensions import ParamSpec
 
 _T_co = TypeVar("_T_co", covariant=True)
 T = TypeVar("T")

--- a/jinja2sql/_core.py
+++ b/jinja2sql/_core.py
@@ -362,7 +362,7 @@ class Jinja2SQL:
 class Jinja2SQLExtension(Extension):
     """Jinja2SQL extension."""
 
-    skip_filters = ("bind", "_bind_in", "safe")
+    skip_filters = ("bind", "_bind_in")
 
     def parse(self, parser: Parser) -> jinja2.nodes.Node | list[jinja2.nodes.Node]:
         """Parse the template."""

--- a/jinja2sql/_core.py
+++ b/jinja2sql/_core.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-import inspect
 import os
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextvars import ContextVar
@@ -156,15 +155,11 @@ class Jinja2SQL:
         """Get the Jinja environment."""
         return self._env
 
-    def register_filter(self, name: str, func: Callable[..., Any]) -> None:
+    def register_filter(
+        self, name: str, func: Callable[..., Any], *, bind: bool = False
+    ) -> None:
         """Register a filter."""
-        has_self = any(
-            param
-            for param in inspect.signature(func).parameters.values()
-            if param.annotation is type(self)
-        )
-
-        if has_self:
+        if bind:
             self._env.filters[name] = lambda *args, **kwargs: func(
                 self, *args, **kwargs
             )
@@ -176,7 +171,7 @@ class Jinja2SQL:
 
     @overload
     def filter(
-        self, *, name: str | None = None
+        self, *, name: str | None = None, bind: bool = False
     ) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
 
     def filter(
@@ -184,10 +179,11 @@ class Jinja2SQL:
         func: Callable[P, T] | None = None,
         *,
         name: str | None = None,
+        bind: bool = False,
     ) -> Callable[[Callable[P, T]], Callable[P, T]] | Callable[P, T]:
         def decorator(func: Callable[P, T]) -> Callable[P, T]:
             _name = name or func.__name__
-            self.register_filter(_name, func)
+            self.register_filter(_name, func, bind=bind)
             return func
 
         if func is None:

--- a/jinja2sql/_core.py
+++ b/jinja2sql/_core.py
@@ -269,9 +269,12 @@ class Jinja2SQL:
         """Begin a render context."""
         token = self._render_context_var.set(
             RenderContext(
-                param_style=param_style or self.param_style,
+                param_style=param_style
+                if param_style is not None
+                else self.param_style,
                 identifier_quote_char=identifier_quote_char
-                or self.identifier_quote_char,
+                if identifier_quote_char is not None
+                else self.identifier_quote_char,
             )
         )
         try:
@@ -423,14 +426,8 @@ class Jinja2SQLExtension(Extension):
 
 def _is_positional_param_style(param_style: ParamStyle | ParamStyleFunc) -> bool:
     """Check if the param_style is positional."""
-    return (
-        param_style
-        in (
-            "qmark",
-            "format",
-            "numeric",
-            "asyncpg",
-        )
-        or callable(param_style)
-        and "key" not in param_style("key", 0)
-    )
+    if param_style in ("qmark", "format", "numeric", "asyncpg"):
+        return True
+    if callable(param_style):
+        return "key" not in param_style("key", 0)
+    return False

--- a/jinja2sql/_core.py
+++ b/jinja2sql/_core.py
@@ -1,22 +1,23 @@
 from __future__ import annotations
 
 import contextlib
-import os
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextvars import ContextVar
 from typing import Any, Literal, ParamSpec, Protocol, TypeAlias, TypeVar, overload
 
 import jinja2
-import jinja2.defaults
 import jinja2.nodes
 from jinja2.ext import Extension
 from jinja2.lexer import Token, TokenStream
 from jinja2.parser import Parser
 from markupsafe import Markup
 
-_T_co = TypeVar("_T_co", covariant=True)
 T = TypeVar("T")
 P = ParamSpec("P")
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
 
 
 class ParamStyleFunc(Protocol):
@@ -27,8 +28,12 @@ ParamStyle = Literal["named", "qmark", "format", "numeric", "pyformat", "asyncpg
 Params: TypeAlias = Mapping[str, Any] | Sequence[Any]
 Context: TypeAlias = Mapping[str, Any]
 
-DEFAULT_IDENTIFIER_QUOTE_CHAR = ""
 DEFAULT_PARAM_STYLE: ParamStyle = "named"
+DEFAULT_IDENTIFIER_QUOTE_CHAR = ""
+
+# ---------------------------------------------------------------------------
+# RenderContext — per-render state
+# ---------------------------------------------------------------------------
 
 
 class RenderContext:
@@ -75,85 +80,113 @@ class RenderContext:
         return param_key, self._param_index
 
 
+# ---------------------------------------------------------------------------
+# Public filter functions
+# ---------------------------------------------------------------------------
+
+
+def _bind_param(
+    self: Jinja2SQL,
+    key: str,
+    value: Any,
+    *,
+    in_clause: bool = False,
+) -> str:
+    """Bind a parameter and return the formatted placeholder."""
+    render_context = self.render_context_var.get()
+    param_key, param_index = render_context.bind_param(key, value, in_clause=in_clause)
+    if callable(param_style := render_context.param_style):
+        return param_style(param_key, param_index)
+    elif param_style == "named":
+        return f":{param_key}"
+    elif param_style == "qmark":
+        return "?"
+    elif param_style == "format":
+        return "%s"
+    elif param_style == "numeric":
+        return f":{param_index}"
+    elif param_style == "pyformat":
+        return f"%({param_key})s"
+    elif param_style == "asyncpg":
+        return f"${param_index}"
+    raise ValueError(f"Invalid param_style - {param_style}")
+
+
+def bind(self: Jinja2SQL, value: Any, name: str) -> Markup | str:
+    """Bind a parameter value to a SQL placeholder."""
+    if isinstance(value, Markup):
+        return value
+    return _bind_param(self, name, value)
+
+
+def bind_in(self: Jinja2SQL, value: Any, name: str) -> str:
+    """Bind multiple values for an IN clause."""
+    values = list(value)
+    if not values:
+        raise ValueError("IN clause cannot be empty.")
+    results = []
+    for item in values:
+        results.append(_bind_param(self, name, item, in_clause=True))
+    return f"({', '.join(results)})"
+
+
+def identifier(self: Jinja2SQL, value: Any) -> Markup:
+    """Escape and quote a SQL identifier."""
+    if isinstance(value, str):
+        parts = (value,)
+    else:
+        parts = value
+    if not isinstance(value, Iterable):
+        raise ValueError("identifier filter expects a string or an Iterable")
+
+    def _quote_and_escape(item: str) -> str:
+        render_context = self.render_context_var.get()
+        quote = render_context.identifier_quote_char
+        return f"{quote}{item.replace(quote, quote * 2)}{quote}"
+
+    return Markup(".".join(_quote_and_escape(item) for item in parts))
+
+
+# ---------------------------------------------------------------------------
+# Jinja2SQL — main class
+# ---------------------------------------------------------------------------
+
+
 class Jinja2SQL:
     def __init__(
         self,
-        searchpath: str
-        | os.PathLike[str]
-        | Sequence[str | os.PathLike[str]]
-        | None = None,
-        block_start_string: str = jinja2.defaults.BLOCK_START_STRING,
-        block_end_string: str = jinja2.defaults.BLOCK_END_STRING,
-        variable_start_string: str = jinja2.defaults.VARIABLE_START_STRING,
-        variable_end_string: str = jinja2.defaults.VARIABLE_END_STRING,
-        comment_start_string: str = jinja2.defaults.COMMENT_START_STRING,
-        comment_end_string: str = jinja2.defaults.COMMENT_END_STRING,
-        line_statement_prefix: str | None = jinja2.defaults.LINE_STATEMENT_PREFIX,
-        line_comment_prefix: str | None = jinja2.defaults.LINE_COMMENT_PREFIX,
-        trim_blocks: bool = jinja2.defaults.TRIM_BLOCKS,
-        lstrip_blocks: bool = jinja2.defaults.LSTRIP_BLOCKS,
-        newline_sequence: Literal[
-            "\n", "\r\n", "\r"
-        ] = jinja2.defaults.NEWLINE_SEQUENCE,
-        keep_trailing_newline: bool = jinja2.defaults.KEEP_TRAILING_NEWLINE,
-        optimized: bool = True,
-        finalize: Callable[..., Any] | None = None,
-        cache_size: int = 400,
-        auto_reload: bool = True,
-        bytecode_cache: jinja2.BytecodeCache | None = None,
-        enable_async: bool = False,
+        env: jinja2.Environment | None = None,
+        *,
         param_style: ParamStyle = DEFAULT_PARAM_STYLE,
         identifier_quote_char: str = DEFAULT_IDENTIFIER_QUOTE_CHAR,
+        autobind: bool = True,
     ):
-        # Set the Jinja loader
-        loader: jinja2.FileSystemLoader | None = None
-        if searchpath:
-            loader = jinja2.FileSystemLoader(searchpath=searchpath)
-
         self.param_style = param_style
         self.identifier_quote_char = identifier_quote_char
-
-        # Set the Jinja environment
-        self._env = jinja2.Environment(
-            block_start_string=block_start_string,
-            block_end_string=block_end_string,
-            variable_start_string=variable_start_string,
-            variable_end_string=variable_end_string,
-            comment_start_string=comment_start_string,
-            comment_end_string=comment_end_string,
-            line_statement_prefix=line_statement_prefix,
-            line_comment_prefix=line_comment_prefix,
-            trim_blocks=trim_blocks,
-            lstrip_blocks=lstrip_blocks,
-            newline_sequence=newline_sequence,
-            keep_trailing_newline=keep_trailing_newline,
-            extensions=(Jinja2SQLExtension,),
-            optimized=optimized,
-            finalize=finalize,
-            autoescape=True,
-            cache_size=cache_size,
-            auto_reload=auto_reload,
-            bytecode_cache=bytecode_cache,
-            enable_async=enable_async,
-            loader=loader,
-        )
-
-        # Default filters
-        self._env.filters["bind"] = self.bind
-        self._env.filters["_bind_in"] = self.bind_in_clause
-        # 'inclause' will be replaced with '_bind_in' in the filter stream
-        self._env.filters["inclause"] = lambda value: value
-        self._env.filters["identifier"] = self.identifier
-
-        # Set the context variable
-        self._render_context_var: ContextVar[RenderContext] = ContextVar(
+        self.render_context_var: ContextVar[RenderContext] = ContextVar(
             "render_context"
         )
+
+        if env is None:
+            env = jinja2.Environment()
+        if autobind:
+            env.add_extension(_AutoBindExtension)
+        env.autoescape = True
+        self._env = env
+
+        # Built-in filters
+        self.register_filter("bind", bind, bind=True)
+        self.register_filter("inclause", bind_in, bind=True)
+        self.register_filter("identifier", identifier, bind=True)
+
+    # -- Properties ---------------------------------------------------------
 
     @property
     def env(self) -> jinja2.Environment:
         """Get the Jinja environment."""
         return self._env
+
+    # -- Filter registration ------------------------------------------------
 
     def register_filter(
         self, name: str, func: Callable[..., Any], *, bind: bool = False
@@ -188,24 +221,9 @@ class Jinja2SQL:
 
         if func is None:
             return decorator
-
         return decorator(func)
 
-    def from_file(
-        self,
-        name: str | jinja2.Template,
-        *,
-        context: Context | None = None,
-        param_style: ParamStyle | ParamStyleFunc | None = None,
-        identifier_quote_char: str | None = None,
-    ) -> tuple[str, Params]:
-        """Load a template from a file."""
-        with self._begin_render_context(
-            param_style=param_style,
-            identifier_quote_char=identifier_quote_char,
-        ):
-            template = self.env.get_template(name)
-            return self._render(template, context)
+    # -- Rendering ----------------------------------------------------------
 
     def from_string(
         self,
@@ -215,7 +233,7 @@ class Jinja2SQL:
         param_style: ParamStyle | ParamStyleFunc | None = None,
         identifier_quote_char: str | None = None,
     ) -> tuple[str, Params]:
-        """Load a template from a string."""
+        """Generate SQL from a string template."""
         with self._begin_render_context(
             param_style=param_style,
             identifier_quote_char=identifier_quote_char,
@@ -223,7 +241,7 @@ class Jinja2SQL:
             template = self.env.from_string(source)
             return self._render(template, context)
 
-    async def from_file_async(
+    def from_file(
         self,
         name: str | jinja2.Template,
         *,
@@ -231,13 +249,13 @@ class Jinja2SQL:
         param_style: ParamStyle | ParamStyleFunc | None = None,
         identifier_quote_char: str | None = None,
     ) -> tuple[str, Params]:
-        """Load a template from a file asynchronously."""
+        """Generate SQL from a file template."""
         with self._begin_render_context(
             param_style=param_style,
             identifier_quote_char=identifier_quote_char,
         ):
             template = self.env.get_template(name)
-            return await self._render_async(template, context)
+            return self._render(template, context)
 
     async def from_string_async(
         self,
@@ -247,7 +265,7 @@ class Jinja2SQL:
         param_style: ParamStyle | ParamStyleFunc | None = None,
         identifier_quote_char: str | None = None,
     ) -> tuple[str, Params]:
-        """Load a template from a string asynchronously."""
+        """Generate SQL from a string template asynchronously."""
         with self._begin_render_context(
             param_style=param_style,
             identifier_quote_char=identifier_quote_char,
@@ -255,14 +273,31 @@ class Jinja2SQL:
             template = self.env.from_string(source)
             return await self._render_async(template, context)
 
+    async def from_file_async(
+        self,
+        name: str | jinja2.Template,
+        *,
+        context: Context | None = None,
+        param_style: ParamStyle | ParamStyleFunc | None = None,
+        identifier_quote_char: str | None = None,
+    ) -> tuple[str, Params]:
+        """Generate SQL from a file template asynchronously."""
+        with self._begin_render_context(
+            param_style=param_style,
+            identifier_quote_char=identifier_quote_char,
+        ):
+            template = self.env.get_template(name)
+            return await self._render_async(template, context)
+
+    # -- Internal -----------------------------------------------------------
+
     @contextlib.contextmanager
     def _begin_render_context(
         self,
         param_style: ParamStyle | ParamStyleFunc | None = None,
         identifier_quote_char: str | None = None,
     ) -> Iterator[None]:
-        """Begin a render context."""
-        token = self._render_context_var.set(
+        token = self.render_context_var.set(
             RenderContext(
                 param_style=param_style
                 if param_style is not None
@@ -275,137 +310,102 @@ class Jinja2SQL:
         try:
             yield
         finally:
-            self._render_context_var.reset(token)
+            self.render_context_var.reset(token)
 
     def _render(
         self, template: jinja2.Template, context: Context | None
     ) -> tuple[str, Params]:
-        """Render a template."""
         query = template.render(context or {})
-        render_context = self._render_context_var.get()
-        return query, render_context.params
+        return query, self.render_context_var.get().params
 
     async def _render_async(
         self, template: jinja2.Template, context: Context | None
     ) -> tuple[str, Params]:
-        """Render a template asynchronously."""
         query = await template.render_async(context or {})
-        render_context = self._render_context_var.get()
-        return query, render_context.params
-
-    def _bind_param(self, key: str, value: Any, *, in_clause: bool = False) -> str:
-        """Bind a parameter."""
-        render_context = self._render_context_var.get()
-        param_key, param_index = render_context.bind_param(
-            key, value, in_clause=in_clause
-        )
-        if callable(param_style := render_context.param_style):
-            return param_style(param_key, param_index)
-        elif param_style == "named":
-            return f":{param_key}"
-        elif param_style == "qmark":
-            return "?"
-        elif param_style == "format":
-            return "%s"
-        elif param_style == "numeric":
-            return f":{param_index}"
-        elif param_style == "pyformat":
-            return f"%({param_key})s"
-        elif param_style == "asyncpg":
-            return f"${param_index}"
-        raise ValueError(f"Invalid param_style - {param_style}")
-
-    def bind(self, value: Any, name: str) -> Markup | str:
-        """Bind a parameter."""
-        if isinstance(value, Markup):
-            return value
-        return self._bind_param(name, value)
-
-    def bind_in_clause(self, value: Any, name: str) -> str:
-        """Bind an IN clause."""
-        values = list(value)
-        if not values:
-            raise ValueError("IN clause cannot be empty.")
-        results = []
-        for item in values:
-            results.append(self._bind_param(name, item, in_clause=True))
-        return f"({', '.join(results)})"
-
-    def identifier(self, value: Any) -> Markup:
-        """Format an identifier."""
-        if isinstance(value, str):
-            identifier = (value,)
-        else:
-            identifier = value
-        if not isinstance(value, Iterable):
-            raise ValueError("identifier filter expects a string or an Iterable")
-
-        def _quote_and_escape(item: str) -> str:
-            render_context = self._render_context_var.get()
-            identifier_quote_char = render_context.identifier_quote_char
-            return "".join(
-                [
-                    identifier_quote_char,
-                    item.replace(
-                        identifier_quote_char,
-                        identifier_quote_char * 2,
-                    ),
-                    identifier_quote_char,
-                ]
-            )
-
-        return Markup(".".join(_quote_and_escape(item) for item in identifier))
+        return query, self.render_context_var.get().params
 
 
-class Jinja2SQLExtension(Extension):
-    """Jinja2SQL extension."""
+# ---------------------------------------------------------------------------
+# Jinja2SQL Extension — auto-binds template variables
+# ---------------------------------------------------------------------------
 
-    skip_filters = ("bind", "_bind_in")
+
+class _AutoBindExtension(Extension):
+    skip_filters = ("bind", "inclause")
 
     def parse(self, parser: Parser) -> jinja2.nodes.Node | list[jinja2.nodes.Node]:
-        """Parse the template."""
         return []
 
     def filter_stream(self, stream: TokenStream) -> Iterable[Token]:
-        """Filter the stream."""
         while not stream.eos:
             token = next(stream)
             if token.test("variable_begin"):
-                var_expr = []
+                var_expr: list[Token] = []
                 while not token.test("variable_end"):
                     var_expr.append(token)
                     token = next(stream)
                 variable_end = token
-                last_token = var_expr[-1]
-                lineno = last_token.lineno
-                if (
-                    not last_token.test("name")
-                    or last_token.value not in self.skip_filters
-                ):
-                    if last_token.value == "inclause":
-                        filter_name = "_bind_in"
-                    else:
-                        filter_name = "bind"
+                lineno = var_expr[-1].lineno
 
+                filter_names = self._filter_names(var_expr)
+                has_inclause = "inclause" in filter_names
+                has_skip = any(n in self.skip_filters for n in filter_names)
+
+                if has_inclause and not self._has_inclause_args(var_expr):
+                    # Add param name argument to inclause
                     param_name = self._extract_param_name(var_expr)
-
+                    self._inject_inclause_arg(var_expr, param_name, lineno)
+                elif not has_skip:
+                    # Wrap with bind filter
+                    param_name = self._extract_param_name(var_expr)
                     var_expr.insert(1, Token(lineno, "lparen", "("))
                     var_expr.append(Token(lineno, "rparen", ")"))
                     var_expr.append(Token(lineno, "pipe", "|"))
-                    var_expr.append(Token(lineno, "name", filter_name))
+                    var_expr.append(Token(lineno, "name", "bind"))
                     var_expr.append(Token(lineno, "lparen", "("))
                     var_expr.append(Token(lineno, "string", param_name))
                     var_expr.append(Token(lineno, "rparen", ")"))
 
                 var_expr.append(variable_end)
-                for token in var_expr:
-                    yield token
+                yield from var_expr
             else:
                 yield token
 
     @staticmethod
+    def _filter_names(tokens: list[Token]) -> list[str]:
+        """Extract filter names from a variable expression (names after pipe)."""
+        names: list[str] = []
+        after_pipe = False
+        for token in tokens:
+            if token.test("pipe"):
+                after_pipe = True
+            elif after_pipe and token.test("name"):
+                names.append(token.value)
+                after_pipe = False
+        return names
+
+    @staticmethod
+    def _has_inclause_args(tokens: list[Token]) -> bool:
+        """Check if inclause already has arguments (e.g. inclause('name'))."""
+        found_inclause = False
+        for token in tokens:
+            if found_inclause and token.test("lparen"):
+                return True
+            found_inclause = token.test("name") and token.value == "inclause"
+        return False
+
+    @staticmethod
+    def _inject_inclause_arg(tokens: list[Token], param_name: str, lineno: int) -> None:
+        """Add param name argument to an existing inclause filter."""
+        for i, token in enumerate(tokens):
+            if token.test("name") and token.value == "inclause":
+                tokens.insert(i + 1, Token(lineno, "lparen", "("))
+                tokens.insert(i + 2, Token(lineno, "string", param_name))
+                tokens.insert(i + 3, Token(lineno, "rparen", ")"))
+                return
+
+    @staticmethod
     def _extract_param_name(tokens: list[Token]) -> str:
-        """Extract the parameter name."""
         name = ""
         for token in tokens:
             if token.test("variable_begin"):
@@ -416,13 +416,17 @@ class Jinja2SQLExtension(Extension):
                 name += token.value
             else:
                 break
-        if not name:
-            name = "bind_0"
-        return name
+        return name or "bind_0"
 
 
-def _is_positional_param_style(param_style: ParamStyle | ParamStyleFunc) -> bool:
-    """Check if the param_style is positional."""
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_positional_param_style(
+    param_style: ParamStyle | ParamStyleFunc,
+) -> bool:
     if param_style in ("qmark", "format", "numeric", "asyncpg"):
         return True
     if callable(param_style):

--- a/jinja2sql/_core.py
+++ b/jinja2sql/_core.py
@@ -328,6 +328,8 @@ class Jinja2SQL:
     def bind_in_clause(self, value: Any, name: str) -> str:
         """Bind an IN clause."""
         values = list(value)
+        if not values:
+            raise ValueError("IN clause cannot be empty.")
         results = []
         for item in values:
             results.append(self._bind_param(name, item, in_clause=True))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
 ]
 dependencies = [
     "jinja2>=3.1.2,<4",
-    "typing-extensions>=4.12.2,<5",
 ]
 
 [project.urls]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,6 @@
 import pathlib
 
+import jinja2
 import pytest
 
 from jinja2sql._core import Jinja2SQL
@@ -18,9 +19,13 @@ def sql_path() -> pathlib.Path:
 
 @pytest.fixture(scope="session")
 def j2sql(sql_path: pathlib.Path) -> Jinja2SQL:
-    return Jinja2SQL(searchpath=sql_path)
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(sql_path))
+    return Jinja2SQL(env)
 
 
 @pytest.fixture(scope="session")
 def async_j2sql(sql_path: pathlib.Path) -> Jinja2SQL:
-    return Jinja2SQL(searchpath=sql_path, enable_async=True)
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(sql_path), enable_async=True
+    )
+    return Jinja2SQL(env)

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,8 +1,9 @@
 import pathlib
 
+import jinja2
 import pytest
 
-from jinja2sql import Jinja2SQL
+from jinja2sql import Jinja2SQL, identifier
 from jinja2sql._core import ParamStyle
 
 from tests.unit.asserts import assert_sql
@@ -15,12 +16,16 @@ def sql_path() -> pathlib.Path:
 
 @pytest.fixture(scope="session")
 def j2sql(sql_path: pathlib.Path) -> Jinja2SQL:
-    return Jinja2SQL(searchpath=sql_path)
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(sql_path))
+    return Jinja2SQL(env)
 
 
 @pytest.fixture(scope="session")
 def async_j2sql(sql_path: pathlib.Path) -> Jinja2SQL:
-    return Jinja2SQL(searchpath=sql_path, enable_async=True)
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(sql_path), enable_async=True
+    )
+    return Jinja2SQL(env)
 
 
 @pytest.mark.parametrize(
@@ -207,6 +212,125 @@ def test_identifier(j2sql: Jinja2SQL) -> None:
     assert params == []
 
 
+@pytest.mark.parametrize(
+    "param_style, expected_query, expected_params",
+    [
+        (
+            "named",
+            "SELECT * FROM table WHERE p1 = :p1__1 AND p2 = :p2__2",
+            {"p1__1": "v1", "p2__2": "v2"},
+        ),
+        (
+            "qmark",
+            "SELECT * FROM table WHERE p1 = ? AND p2 = ?",
+            ["v1", "v2"],
+        ),
+        (
+            "asyncpg",
+            "SELECT * FROM table WHERE p1 = $1 AND p2 = $2",
+            ["v1", "v2"],
+        ),
+    ],
+)
+def test_explicit_bind(
+    j2sql: Jinja2SQL,
+    param_style: ParamStyle,
+    expected_query: str,
+    expected_params: dict[str, str] | list[str],
+) -> None:
+    query, params = j2sql.from_string(
+        "SELECT * FROM table"
+        " WHERE p1 = {{ p1 | bind('p1') }}"
+        " AND p2 = {{ p2 | bind('p2') }}",
+        context={"p1": "v1", "p2": "v2"},
+        param_style=param_style,
+    )
+
+    assert_sql(query, expected_query)
+    assert params == expected_params
+
+
+def test_explicit_bind_in(j2sql: Jinja2SQL) -> None:
+    query, params = j2sql.from_string(
+        "SELECT * FROM table WHERE param IN {{ items | inclause('items') }}",
+        context={"items": ["a", "b"]},
+        param_style="named",
+    )
+
+    assert_sql(
+        query,
+        "SELECT * FROM table WHERE param IN (:items__in__1, :items__in__2)",
+    )
+    assert params == {"items__in__1": "a", "items__in__2": "b"}
+
+
+def test_explicit_identifier(j2sql: Jinja2SQL) -> None:
+    query, params = j2sql.from_string(
+        "SELECT * FROM {{ table | identifier }}",
+        context={"table": "users"},
+        param_style="named",
+        identifier_quote_char='"',
+    )
+
+    assert_sql(query, 'SELECT * FROM "users"')
+    assert params == {}
+
+
+def test_explicit_bind_with_other_filters(j2sql: Jinja2SQL) -> None:
+    query, params = j2sql.from_string(
+        "SELECT * FROM table WHERE param = {{ param | upper | bind('param') }}",
+        context={"param": "value"},
+        param_style="named",
+    )
+
+    assert_sql(query, "SELECT * FROM table WHERE param = :param__1")
+    assert params == {"param__1": "VALUE"}
+
+
+def test_autobind_false() -> None:
+    j2sql = Jinja2SQL(autobind=False)
+
+    query, params = j2sql.from_string(
+        "SELECT * FROM {{ table | identifier }}"
+        " WHERE p1 = {{ p1 | bind('p1') }}"
+        " AND p2 = {{ p2 | bind('p2') }}",
+        context={"table": "users", "p1": "v1", "p2": "v2"},
+        param_style="named",
+    )
+
+    assert_sql(query, "SELECT * FROM users WHERE p1 = :p1__1 AND p2 = :p2__2")
+    assert params == {"p1__1": "v1", "p2__2": "v2"}
+
+
+def test_autobind_false_inclause() -> None:
+    j2sql = Jinja2SQL(autobind=False)
+
+    query, params = j2sql.from_string(
+        "SELECT * FROM table WHERE param IN {{ items | inclause('items') }}",
+        context={"items": ["a", "b"]},
+        param_style="named",
+    )
+
+    assert_sql(
+        query,
+        "SELECT * FROM table WHERE param IN (:items__in__1, :items__in__2)",
+    )
+    assert params == {"items__in__1": "a", "items__in__2": "b"}
+
+
+def test_autobind_false_no_bind_renders_raw() -> None:
+    j2sql = Jinja2SQL(autobind=False)
+
+    query, params = j2sql.from_string(
+        "SELECT * FROM table WHERE param = {{ param }}",
+        context={"param": "value"},
+        param_style="named",
+    )
+
+    assert_sql(query, "SELECT * FROM table WHERE param = value")
+    assert params == {}
+
+
 def test_safe_sql(j2sql: Jinja2SQL) -> None:
     query, params = j2sql.from_string(
         "SELECT * FROM table WHERE param = '{{ param | safe }}'",
@@ -288,7 +412,8 @@ def test_register_filter_with_bind() -> None:
     j2sql = Jinja2SQL()
 
     def array_filter(j2sql: Jinja2SQL, value: list[str]) -> str:
-        return j2sql.identifier(", ".join(f"'{item}'" for item in value))
+        parts = ", ".join(f"'{item}'" for item in value)
+        return identifier(j2sql, parts)
 
     j2sql.register_filter("array", array_filter, bind=True)
 
@@ -326,7 +451,8 @@ def test_filter_decorator_with_bind() -> None:
 
     @j2sql.filter(name="array2", bind=True)
     def array_filter(j2sql: Jinja2SQL, value: list[str]) -> str:
-        return j2sql.identifier(", ".join(f"'{item}'" for item in value))
+        parts = ", ".join(f"'{item}'" for item in value)
+        return identifier(j2sql, parts)
 
     query, params = j2sql.from_string(
         """SELECT ARRAY[{{ param | array2 }}] AS array""",

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -260,7 +260,8 @@ async def test_from_file_async(async_j2sql: Jinja2SQL) -> None:
     assert params == [param1, param2]
 
 
-def test_register_filter(j2sql: Jinja2SQL) -> None:
+def test_register_filter() -> None:
+    j2sql = Jinja2SQL()
     j2sql.register_filter("custom_filter", lambda value: f"{value}_with_filter")
 
     query, params = j2sql.from_string(
@@ -274,7 +275,9 @@ def test_register_filter(j2sql: Jinja2SQL) -> None:
     assert params == {"param__1": "value_with_filter"}
 
 
-def test_register_filter_with_self(j2sql: Jinja2SQL) -> None:
+def test_register_filter_with_self() -> None:
+    j2sql = Jinja2SQL()
+
     def array_filter(j2sql: Jinja2SQL, value: list[str]) -> str:
         return j2sql.identifier(", ".join(f"'{item}'" for item in value))
 
@@ -291,7 +294,9 @@ def test_register_filter_with_self(j2sql: Jinja2SQL) -> None:
     assert params == {}
 
 
-def test_filter_decorator(j2sql: Jinja2SQL) -> None:
+def test_filter_decorator() -> None:
+    j2sql = Jinja2SQL()
+
     @j2sql.filter
     def custom_filter2(value: str) -> str:
         return f"{value}_with_decorator"
@@ -307,7 +312,9 @@ def test_filter_decorator(j2sql: Jinja2SQL) -> None:
     assert params == {"param__1": "value_with_decorator"}
 
 
-def test_filter_decorator_with_self(j2sql: Jinja2SQL) -> None:
+def test_filter_decorator_with_self() -> None:
+    j2sql = Jinja2SQL()
+
     @j2sql.filter(name="array2")
     def array_filter(self: Jinja2SQL, value: list[str]) -> str:
         return self.identifier(", ".join(f"'{item}'" for item in value))

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -106,6 +106,15 @@ def test_bind_inclause_params_with_positional_param_style(
     assert params == [value1, value2]
 
 
+def test_bind_inclause_empty_list(j2sql: Jinja2SQL) -> None:
+    with pytest.raises(ValueError, match="IN clause cannot be empty"):
+        j2sql.from_string(
+            "SELECT * FROM table WHERE param IN {{ list_param | inclause }}",
+            context={"list_param": []},
+            param_style="named",
+        )
+
+
 @pytest.mark.parametrize(
     "param_style, expected_query",
     [

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -284,13 +284,13 @@ def test_register_filter() -> None:
     assert params == {"param__1": "value_with_filter"}
 
 
-def test_register_filter_with_self() -> None:
+def test_register_filter_with_bind() -> None:
     j2sql = Jinja2SQL()
 
     def array_filter(j2sql: Jinja2SQL, value: list[str]) -> str:
         return j2sql.identifier(", ".join(f"'{item}'" for item in value))
 
-    j2sql.register_filter("array", array_filter)
+    j2sql.register_filter("array", array_filter, bind=True)
 
     query, params = j2sql.from_string(
         """SELECT ARRAY[{{ param | array }}] AS array""",
@@ -321,12 +321,12 @@ def test_filter_decorator() -> None:
     assert params == {"param__1": "value_with_decorator"}
 
 
-def test_filter_decorator_with_self() -> None:
+def test_filter_decorator_with_bind() -> None:
     j2sql = Jinja2SQL()
 
-    @j2sql.filter(name="array2")
-    def array_filter(self: Jinja2SQL, value: list[str]) -> str:
-        return self.identifier(", ".join(f"'{item}'" for item in value))
+    @j2sql.filter(name="array2", bind=True)
+    def array_filter(j2sql: Jinja2SQL, value: list[str]) -> str:
+        return j2sql.identifier(", ".join(f"'{item}'" for item in value))
 
     query, params = j2sql.from_string(
         """SELECT ARRAY[{{ param | array2 }}] AS array""",

--- a/uv.lock
+++ b/uv.lock
@@ -327,7 +327,6 @@ version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
-    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -347,10 +346,7 @@ docs = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "jinja2", specifier = ">=3.1.2,<4" },
-    { name = "typing-extensions", specifier = ">=4.12.2,<5" },
-]
+requires-dist = [{ name = "jinja2", specifier = ">=3.1.2,<4" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- **Simplified constructor**: `Jinja2SQL` now accepts an optional `jinja2.Environment` instead of 18+ Jinja2 parameters
- **Extracted filter functions**: `bind`, `bind_in`, `identifier` are standalone public functions, registered via `register_filter`
- **Explicit `bind` parameter**: replaced introspection-based self-detection in `register_filter`/`@filter` with `bind=True` (Celery-style)
- **`autobind` flag**: `Jinja2SQL(autobind=False)` disables auto-binding for explicit `{{ param | bind('param') }}` usage
- **`inclause` is now a real filter**: no more internal `_bind_in` mapping, works with both `autobind=True` and `autobind=False`
- **Fixed `_AutoBindExtension`**: filter detection now scans all tokens after pipe, not just the last token
- **Fixed `identifier_quote_char`/`param_style` override**: `or` replaced with `is not None` check
- **Removed `typing-extensions` dependency**: `ParamSpec` imported from stdlib `typing` (Python 3.10+)
- **Updated docs**: Python 3.10+ requirement, `safe` filter warning, `autobind=False` usage, inline env examples
- **Raise `ValueError` on empty IN clause**
- **Isolated filter tests** from shared session-scoped fixture

## Test plan

- [x] 34 unit tests passing
- [x] SQLite/SQLAlchemy integration tests passing
- [x] mypy strict, ruff check, ruff format — all clean
- [x] Explicit `bind`/`inclause`/`identifier` filters work with and without `autobind`